### PR TITLE
Add support for files being loaded via load and using (in-ns 'foo).

### DIFF
--- a/lein-light-nrepl/src/lighttable/nrepl/eval.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/eval.clj
@@ -133,8 +133,16 @@
 
 (defn ->ns [content]
   (try
-    (let [c (read-string content)]
-      (name (first (filter symbol? (rest c)))))
+    (let [c (read-string content)
+          ns-type (name (first c))]
+      (case ns-type
+        "ns" (name (first (filter symbol? (rest c))))
+        "in-ns" (-> c
+                    rest
+                    first
+                    second
+                    name)
+        nil))
     (catch Exception e
       )))
 


### PR DESCRIPTION
The original version only supported (ns foo) style forms and threw
errors when using load/in-ns. With this change we also support using
(in-ns 'foo) and loading said file via (load ...).
