### PR TITLE
Add angle brackets to keyword matching

### DIFF
--- a/codemirror/clojure-mode.js
+++ b/codemirror/clojure-mode.js
@@ -46,7 +46,7 @@ CodeMirror.defineMode("clojure", function () {
     char: /[^\s\(\[\{\}\]\)]/,
     keyword_char: /[^\s\(\[\;\)\]]/,
     basic: /[\w\$_\-\.\*\+\/\?\><!]/,
-    lang_keyword: /[\w\*\+!\-_?:\/\.#=]/,
+    lang_keyword: /[\w\*\+!\-_?:\/\.#=><]/,
   };
 
   function stateStack(indent, type, prev) { // represents a state stack object


### PR DESCRIPTION
Keywords containing angle brackets are now highlighted correctly.

Fixes #5.
