### PR TITLE
do not eat spaces when inside string

### DIFF
--- a/codemirror/clojure-mode.js
+++ b/codemirror/clojure-mode.js
@@ -177,7 +177,7 @@ CodeMirror.defineMode("clojure", function () {
       }
 
       // skip spaces
-      if (stream.eatSpace()) {
+      if (state.mode != "string" && stream.eatSpace()) {
         return null;
       }
       var returnType = null;


### PR DESCRIPTION
Currently when a string starts with whitespace the tokentype of that whitespace returns nil, not string. I compared this to javascript/common lisp syntax where it does return string. Turns out it eats the spaces at the beginning of a string even though it is in string mode already.
