### PR TITLE
Fully qualify name of langs.clj object

### DIFF
--- a/src/lt/plugins/clojure.cljs
+++ b/src/lt/plugins/clojure.cljs
@@ -426,10 +426,10 @@
           :reaction (fn [this res len]
                       len))
 
-(object/object* :langs.clj
+(object/object* ::langs.clj
                 :tags #{:clojure.lang})
 
-(def clj-lang (object/create :langs.clj))
+(def clj-lang (object/create ::langs.clj))
 
 (behavior ::java-exe
           :triggers #{:object.instant}


### PR DESCRIPTION
As far as I can tell while casually browsing objects, the definition of `langs.clj` is the only one not using a qualified keyword.
