### PR TITLE
Update to clojurescript 0.0-2202

### DIFF
--- a/lein-light-nrepl/project.clj
+++ b/lein-light-nrepl/project.clj
@@ -11,7 +11,7 @@
                  [ibdknox/analyzer "0.0.2"]
                  [clj-stacktrace "0.2.7"]
                  [fs "1.3.3"]
-                 [org.clojure/clojurescript "0.0-2173"
+                 [org.clojure/clojurescript "0.0-2202"
                    :exclusions [org.apache.ant/ant]]
                  [com.cemerick/pomegranate "0.2.0"]
                  [clojure-complete "0.2.3"]

--- a/lein-light-nrepl/src/lighttable/nrepl/cljs.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/cljs.clj
@@ -9,6 +9,7 @@
             [lighttable.nrepl.exception :as exception]
             [cljs.compiler :as comp]
             [cljs.analyzer :as cljs]
+            [cljs.js-deps :as js-deps]
             [cljs.source-map :as sm]
             [cljs.env :as cljs-env :refer [with-compiler-env]]
             [clojure.test :as test]
@@ -185,7 +186,7 @@
     {(-> dep :name) dep}))
 
 (defn js-dep [{:keys [ns]}]
-  (when-let [dep (get (cljsc/js-dependency-index {}) (str ns))]
+  (when-let [dep (get (js-deps/js-dependency-index {}) (str ns))]
     (let [deps (:requires dep)
           deps (if (not= ns 'goog)
                  (conj deps 'goog)


### PR DESCRIPTION
Hi,

I updated CLJS to latest version. This fixes problem with "No such var: cljsc/js-dependency-index" in projects with latest cljs.
