### PR TITLE
add -Djava.awt.headless=true

### DIFF
--- a/runner/src/leiningen/light_nrepl.clj
+++ b/runner/src/leiningen/light_nrepl.clj
@@ -36,7 +36,8 @@
         profile {:dependencies '[[lein-light-nrepl/lein-light-nrepl "0.0.18"]
                                  [org.clojure/tools.reader "0.8.3"]]
                  :repl-options {:nrepl-middleware ['lighttable.nrepl.handler/lighttable-ops]
-                                 :init (with-meta init {:replace true})}}
+                                 :init (with-meta init {:replace true})}
+                 :jvm-opts ["-Djava.awt.headless=true"]}
         project (lp/merge-profiles project [profile])]
     (println "final project: " project)
       project))

--- a/src/lt/plugins/clojure.cljs
+++ b/src/lt/plugins/clojure.cljs
@@ -811,7 +811,7 @@
 
 (defn run-jar [{:keys [path project-path name client]}]
   (let [obj (object/create ::connecting-notifier n (clients/->id client))
-        args ["-Xmx1g" "-jar" (windows-escape jar-path)]]
+        args ["-Xmx1g" "-Djava.awt.headless=true" "-jar" (windows-escape jar-path)]]
     (notifos/working "Connecting..")
     (.write console/core-log (str "STARTING CLIENT: " (jar-command project-path name client)))
     (proc/exec {:command (or (:java-exe @clj-lang) "java")


### PR DESCRIPTION
This prevents annoying dock icons from appearing when connecting to a clojure project.
