### PR TITLE
Add refresh connection command to make figwheel-like workflows possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ There are 3 ways to eval ClojureScript, 2 of which use your ClojureScript javasc
 For ClojureScript projects:
 
 Your project is connected to a browser. Recompile cljs outside of LT with project's cljs compile tool e.g. `lein cljsbuild auto`.
-Most changes can be evaled. However, if adding project dependencies or requires to ns, refresh the browser page after cljs has been compiled.
+Most changes can be evaled. However, if adding project dependencies or requires to ns, use the `:client.refresh-connection` command
+to refresh the browser page. To automate this on-save, add this to `user.behaviors`:
+
+```clojurescript
+:editor.clojurescript [(:lt.objs.editor.file/on-save :client.refresh-connection)]
+```
 
 For LightTable plugins:
 

--- a/src/lt/plugins/clojure.cljs
+++ b/src/lt/plugins/clojure.cljs
@@ -10,6 +10,7 @@
             [lt.objs.deploy :as deploy]
             [lt.objs.console :as console]
             [lt.objs.editor :as ed]
+            [lt.objs.editor.pool :as pool]
             [lt.objs.connector :as connector]
             [lt.objs.popup :as popup]
             [lt.objs.platform :as platform]
@@ -868,3 +869,9 @@
                 :tags #{:clojure.lang})
 
 (def clj-lang (object/create ::langs.clj))
+
+(cmd/command {:command :client.refresh-connection
+              :desc "Client: Refresh client connection"
+              :exec (fn []
+                      (when-let [client (-> (pool/last-active) deref :client :exec)]
+                        (object/raise client :client.refresh!)))})


### PR DESCRIPTION
This command is generic enough that it could move to core at a later date. I can't think of other clients that currently need this since js already has this behavior. Plan on releasing this tomorrow unless there's feedback. I'll make sure to compile cljs before a release of course
