### PR TITLE
conservatively inlining the most likely deps that could crash with project versions

### DIFF
--- a/lein-light-nrepl/README.md
+++ b/lein-light-nrepl/README.md
@@ -1,3 +1,18 @@
 # lein-light-nrepl
 
 lein-light-nrepl is the nrepl-based client for Light Table's clojure and clojurescript evaluation. Basically everything that requires the JVM will be found in this project.
+
+
+## Building
+
+Some dependencies have been inlined using [mranderson](https://github.com/benedekfazekas/mranderson). Hence building and working with the project
+is a little more cumbersome. Please consult the readme for mranderson.
+
+
+- `lein source-deps` Will do the work with inlining dependencies
+- `lein with-profile plugin.mranderson/config install` will install the dependency inlined jar to your local repo
+- `lein with-profile +plugin.mranderson/config deploy clojars` - for releasing a version to clojars
+- `lein clean` if you add or remove dependencies
+
+
+Note: When developing locally with mranderson, you'll need to modify source in `target/srcdeps`

--- a/lein-light-nrepl/project.clj
+++ b/lein-light-nrepl/project.clj
@@ -3,16 +3,16 @@
   :url "https://github.com/LightTable/Clojure/tree/master/lein-light-nrepl"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :plugins [[thomasa/mranderson "0.4.3"]]
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.nrepl "0.2.3"]
                  [commons-io/commons-io "2.4"]
-                 [ibdknox/tools.reader "0.8.1"]
-                 [org.clojure/tools.reader "0.7.10"]
+                 ^:source-dep [org.clojure/tools.reader "0.9.2"]
                  [ibdknox/analyzer "0.0.2"]
-                 [clj-stacktrace "0.2.7"]
+                 ^:source-dep [clj-stacktrace "0.2.7"]
                  [fs "1.3.3"]
                  [org.clojure/clojurescript "0.0-2202"
                    :exclusions [org.apache.ant/ant]]
                  [clojure-complete "0.2.3"]
-                 [cheshire "5.2.0"]]
+                 ^:source-dep [cheshire "5.2.0"]]
   :jvm-opts ["-Xmx1g"])

--- a/lein-light-nrepl/src/lighttable/nrepl/cljs.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/cljs.clj
@@ -19,8 +19,8 @@
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.middleware.interruptible-eval :refer [interruptible-eval *msg*]]
             [clojure.tools.nrepl.misc :refer [response-for returning]]
-            [ibdknox.tools.reader :as reader]
-            [ibdknox.tools.reader.reader-types :as rt])
+            [clojure.tools.reader :as reader]
+            [clojure.tools.reader.reader-types :as rt])
   (:import java.io.Writer))
 
 (def js-dependency-index

--- a/lein-light-nrepl/src/lighttable/nrepl/eval.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/eval.clj
@@ -9,8 +9,8 @@
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [clojure.tools.nrepl.middleware.interruptible-eval :refer [interruptible-eval *msg*]]
             [clojure.tools.nrepl.misc :refer [response-for returning]]
-            [ibdknox.tools.reader :as reader]
-            [ibdknox.tools.reader.reader-types :as rt])
+            [clojure.tools.reader :as reader]
+            [clojure.tools.reader.reader-types :as rt])
   (:import java.io.Writer))
 
 (defn try-read [rdr]


### PR DESCRIPTION
First attempt at addressing #44 

Took the liberty of upping tools.reader to a sensibly up to date version while at it.