### PR TITLE
Removed FS dependency

### DIFF
--- a/lein-light-nrepl/project.clj
+++ b/lein-light-nrepl/project.clj
@@ -10,7 +10,6 @@
                  [org.clojure/tools.reader "0.7.10"]
                  [ibdknox/analyzer "0.0.2"]
                  [clj-stacktrace "0.2.7"]
-                 [fs "1.3.3"]
                  [org.clojure/clojurescript "0.0-2202"
                    :exclusions [org.apache.ant/ant]]
                  [clojure-complete "0.2.3"]

--- a/lein-light-nrepl/src/lighttable/nrepl/cljs.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/cljs.clj
@@ -3,7 +3,7 @@
             [clojure.pprint :refer [pprint]]
             [clojure.test :as test]
             [clojure.string :as string]
-            [fs.core :as fs]
+            [lighttable.nrepl.fs :as fs]
             [lighttable.nrepl.eval :as eval]
             [lighttable.nrepl.core :as core]
             [lighttable.nrepl.exception :as exception]

--- a/lein-light-nrepl/src/lighttable/nrepl/core.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/core.clj
@@ -7,7 +7,7 @@
             [clojure.tools.nrepl.middleware :refer [set-descriptor!]]
             [cheshire.core :as cheshire]
             [clj-stacktrace.repl :refer [pst+]]
-            [fs.core :as fs]
+            [lighttable.nrepl.fs :as fs]
             [clojure.repl :as repl]))
 
 (def ^{:dynamic true} *ltmsg* nil)
@@ -18,7 +18,7 @@
 (def old-*out* *out*)
 (def old-*err* *err*)
 (def my-settings (atom {:name "clj"
-                        :dir (fs/absolute-path fs/*cwd*)
+                        :dir (fs/absolute-path fs/cwd)
                         :type "lein-light-nrepl"
                         :commands [:editor.eval.clj
                                    :editor.clj.doc

--- a/lein-light-nrepl/src/lighttable/nrepl/fs.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/fs.clj
@@ -1,0 +1,14 @@
+(ns lighttable.nrepl.fs
+  (:require
+    [clojure.java.io :as io]))
+
+(defn exists? [path]
+  (.exists (io/file path)))
+
+(defn absolute-path [path]
+  (.getAbsolutePath (io/file path)))
+
+(defn mod-time [path]
+  (.lastModified (io/file path)))
+
+(def cwd (.getCanonicalFile (io/file ".")))

--- a/lein-light-nrepl/src/lighttable/nrepl/handler.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/handler.clj
@@ -12,7 +12,6 @@
             [lighttable.nrepl.doc :as doc]
             lighttable.nrepl.auto-complete
             [clj-stacktrace.repl :as stack :refer [pst+]]
-            [fs.core :as fs]
             [clojure.repl :as repl]))
 
 (defn with-lt-data [msg]


### PR DESCRIPTION
`lein-light-nrepl` used to depend on `fs` library. This library is unstable (they change public API all too often), and is used in other projects (figwheel, lein-cljsbuild). It was a source of great pain (https://github.com/bhauman/lein-figwheel/issues/119, https://github.com/bhauman/lein-figwheel/issues/11, https://github.com/LightTable/LightTable/issues/1482, https://github.com/bhauman/devcards/issues/14).

Turned out it was not crucial to have this lib as a dependency. It was used rarely and for pretty trivial stuff. So I just removed it.