### PR TITLE
Commands needs to be set for client connection selection.

### DIFF
--- a/lein-light-nrepl/src/lighttable/nrepl/core.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/core.clj
@@ -18,7 +18,17 @@
 (def old-*err* *err*)
 (def my-settings (atom {:name "clj"
                         :dir (fs/absolute-path fs/cwd)
-                        :type "lein-light-nrepl"}))
+                        :type "lein-light-nrepl"
+                        :commands [:editor.eval.clj
+                                   :editor.clj.doc
+                                   :editor.cljs.doc
+                                   :editor.clj.hints
+                                   :editor.cljs.hints
+                                   :docs.clj.search
+                                   :docs.cljs.search
+                                   :editor.eval.clj.cancel
+                                   :editor.eval.cljs
+                                   :cljs.compile]}))
 
 (defmulti handle :op)
 


### PR DESCRIPTION
This paritally reverts 65ebb33f3940940b120e98754a2c8a5570d120c2

LT creates a new connection for each namespace upon eval when using clojure >= 1.7 (which forces lein-light-nrepl 0.3.0 to be used). 

Steps to reproduce:
1) In a project using clojure >= 1.7
2) Open a namespace and eval something -> Connection automatically added, but not that no commands are listed in the connect bar for the connection
3) Open another namespace and eval something there -> another connection is spawned
4) and so on...

The commands are added to the connection in https://github.com/LightTable/Clojure/blob/master/src/lt/plugins/clojure/nrepl.cljs#L122

When we later try to look up a connection like in eval, we pass a command which is used to locate an appropriate connection like in https://github.com/LightTable/Clojure/blob/master/src/lt/plugins/clojure.cljs#L185
. If this fails (which it does because no commands are stored in already created connections), a new connection is spawned by the try-connect function passed with the create key.
