### PR TITLE
replace clj-stacktrace with aviso/pretty - follow up on #77

### DIFF
--- a/lein-light-nrepl/project.clj
+++ b/lein-light-nrepl/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-light-nrepl "0.3.2"
+(defproject lein-light-nrepl "0.3.3"
   :description "nrepl client for Light Table clj and cljs eval."
   :url "https://github.com/LightTable/Clojure/tree/master/lein-light-nrepl"
   :license {:name "Eclipse Public License"
@@ -7,7 +7,7 @@
                  [org.clojure/tools.nrepl "0.2.10"]
                  [commons-io/commons-io "2.4"]
                  [org.clojure/tools.reader "0.9.2"]
-                 [clj-stacktrace "0.2.8"]
+                 [io.aviso/pretty "0.1.25"]
                  [org.clojure/clojurescript "0.0-3308"
                    :exclusions [org.apache.ant/ant]]
                  [clojure-complete "0.2.4"]]

--- a/lein-light-nrepl/src/lighttable/nrepl/exception.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/exception.clj
@@ -1,22 +1,10 @@
 (ns lighttable.nrepl.exception
   (:require [clojure.string :as string]
-            [clj-stacktrace.repl :as exc]))
+            [io.aviso.exception :as aviso]))
 
-(def reader-trace #"(?s)\s*(core.clj:4227 clojure.core/ex-info)?\s*reader_types.clj:219.*")
-(def eval-trace #"(?s)\s*Compiler.java:6619.*")
-(def analyzer-trace #"(?s)\s*Compiler.java:[\d]+ clojure.lang.Compiler.analyze.*")
-(def cljs-eval #"(?s)\scljs.clj:[\d]+ lighttable.nrepl.cljs/eval-cljs.*")
+;; (def reader-trace #"(?s)\s*(core.clj:4227 clojure.core/ex-info)?\s*reader_types.clj:219.*")
+;; (def eval-trace #"(?s)\s*Compiler.java:6619.*")
+;; (def analyzer-trace #"(?s)\s*Compiler.java:[\d]+ clojure.lang.Compiler.analyze.*")
+;; (def cljs-eval #"(?s)\scljs.clj:[\d]+ lighttable.nrepl.cljs/eval-cljs.*")
 
-(defn add-ex-data [s e]
-  (if-let [data (ex-data e)]
-    (string/replace-first s #"\n" (str " :: " (pr-str data) "\n"))
-    s))
-
-(defn clean-trace [e]
-  (-> (exc/pst-str e)
-      (string/replace eval-trace "")
-      (string/replace reader-trace "")
-      (string/replace analyzer-trace "")
-      (string/replace cljs-eval "")
-      (add-ex-data e)
-      ))
+(def clean-trace aviso/format-exception)

--- a/src/lt/plugins/clojure.cljs
+++ b/src/lt/plugins/clojure.cljs
@@ -381,6 +381,11 @@
                           (object/raise handler ev {:result (:result result)
                                                     :meta meta})))))
 
+(defn strip-ansi
+  "Removes ANSI codes from a string, returning just the raw text."
+  [string]
+  (clojure.string/replace string #"\u001b\[.*?m" ""))
+
 (behavior ::clj-exception
           :triggers #{:editor.eval.clj.exception}
           :reaction (fn [obj res passed?]
@@ -390,7 +395,7 @@
                             loc {:line (dec (:end-line meta)) :ch (:end-column meta 0)
                                  :start-line (dec (:line meta 1))}]
                         (notifos/set-msg! (:result res) {:class "error"})
-                        (object/raise obj :editor.exception (:stack res) loc))
+                        (object/raise obj :editor.exception (strip-ansi (:stack res)) loc))
                       ))
 
 (behavior ::cljs-exception
@@ -412,8 +417,8 @@
                                             (pr-str (:ex res)))))
                                       msg
                                       "Unknown error")]
-                        (notifos/set-msg! msg {:class "error"})
-                        (object/raise obj :editor.exception stack loc))
+                        (notifos/set-msg! (strip-ansi msg) {:class "error"})
+                        (object/raise obj :editor.exception (strip-ansi stack) loc))
                       ))
 
 (behavior ::eval-print

--- a/src/lt/plugins/clojure/collapsible_exception.cljs
+++ b/src/lt/plugins/clojure/collapsible_exception.cljs
@@ -145,7 +145,7 @@
                       (let [meta (:meta res)
                             loc {:line (dec (:end-line meta)) :ch (:end-column meta)
                                  :start-line (dec (:line meta))}
-                            msg (or (:stack res) (truncate (:ex res)))
+                            msg (truncate (or (:stack res) (:ex res)))
                             stack (cond
                                     (:stack res)                           (:stack res)
                                     (and (:ex res) (.-stack (:ex res)))    (.-stack (:ex res))

--- a/src/lt/plugins/clojure/collapsible_exception.cljs
+++ b/src/lt/plugins/clojure/collapsible_exception.cljs
@@ -134,7 +134,7 @@
                       (let [meta (:meta res)
                             loc {:line (dec (:end-line meta)) :ch (:end-column meta 0)
                                  :start-line (dec (:line meta 1))}]
-                        (notifos/set-msg! (:result res) {:class "error"})
+                        (notifos/set-msg! (truncate (:result res)) {:class "error"})
                         (object/raise obj :editor.exception.collapsible (:result res) (:stack res) loc))))
 
 (behavior ::cljs-expandable-exception

--- a/src/lt/plugins/clojure/collapsible_exception.cljs
+++ b/src/lt/plugins/clojure/collapsible_exception.cljs
@@ -8,6 +8,58 @@
 
 (def ^:private ^:const NOT_FOUND -1)
 
+(def ^:const ^:private ansi-set&reset #"(.*?)\u001b\[([\d+;]+)m(.*?)\u001b\[m\s*")
+(def ^:const ^:private ansi-set #"(.*?)\u001b\[([\d+;]+)m(.*)")
+
+(def ^:const ^:private span-font
+  {:bold "font-weight: bold", :italic "font-style: italic"})
+(def ^:const ^:private span-color
+  {"30" "black", "31" "OrangeRed", "32" "limegreen", "33" "yellow",
+   "34" "blue", "35" "purple", "36" "cyan", "37" "white"})
+
+(defn mods->css
+  "takes a string with the ansi codes (ex: 1;31) and returns a string with
+  the equivalent CSS style to use"
+  [mods]
+  (clojure.string/join ";"
+    (for [modifier (clojure.string/split mods #";")]
+      (condp = modifier
+        "1" (:bold span-font)
+        "3" (:italic span-font)
+        (str "color:" (get span-color modifier))))))
+
+(defn- inner-span
+  "takes a text with a single ansi-code font change and returns a list with
+  the preceding text and a styled span according to the ansi code"
+  [text]
+  (let [csi-inner    (zipmap [:match :start :mods :content] (re-find ansi-set text))
+        span-style   (mods->css (:mods csi-inner))
+        span-content (:content csi-inner)]
+    (if (empty? csi-inner) (list text)
+      (list (:start csi-inner) [:span {:style span-style} span-content]))))
+
+(defn- spanner
+  "takes a text-line with ansi code and transforms it into a sequence of spans
+  for each ansi font change. The original format is preserved. Each span has
+  its own style according to the ansi code used. See span-font and span-color
+  for more details"
+  [text]
+  (when-not (empty? text)
+    (let [csi-text     (zipmap [:match :space :mods :content] (re-find ansi-set&reset text))
+          span-style   (mods->css (:mods csi-text))
+          span-content (cons (:space csi-text) (inner-span (:content csi-text)))]
+      (if (empty? csi-text) text
+        (cons [:span {:style span-style} span-content]
+              (spanner (subs text (count (:match csi-text)))))))))
+
+(defn- ansi->hiccup
+  "takes a full stacktrace text with ansi code and transforms it into sequence of divs for
+  each line, and spans for each ansi font change. Returns a hiccup structure"
+  [stack-text]
+  (let [stack-lines (clojure.string/split-lines stack-text)
+        div-lines   (map #(vector :div (spanner %)) stack-lines)]
+    [:span.full div-lines]))
+
 (defn truncate
   "truncate a string at newline or at 100 characters long"
   [text]
@@ -15,6 +67,11 @@
     (if (= NOT_FOUND (.indexOf text "\n"))
       (subs text 0 100); take 100 characters
       (first (clojure.string/split-lines text)))))
+
+(defn strip-ansi
+  "Removes ANSI codes from a string, returning just the raw text."
+  [string]
+  (clojure.string/replace string #"\u001b\[.*?m" ""))
 
 (defn ->collapse-class [this summary]
   (str "inline-exception result-mark"
@@ -27,7 +84,7 @@
             :style "background: #73404c; color: #ffa6a6;
                     max-width:initial; max-height:initial"}
      [:span.truncated summary]
-     [:span.full stacktrace]])
+     (ansi->hiccup stacktrace)])
   :mousewheel (fn [e] (dom/stop-propagation e))
   :click      (fn [e] (dom/prevent e)
                       (object/raise this :click))
@@ -96,5 +153,5 @@
                                     (and (:ex res) (not (:verbatim meta))) (pr-str (:ex res))
                                     (not (nil? msg))                       (or (:stack res) (:ex res)); untruncated stacktrace
                                     :else "Unknown error")]
-                        (notifos/set-msg! msg {:class "error"})
+                        (notifos/set-msg! (strip-ansi msg) {:class "error"})
                         (object/raise obj :editor.exception.collapsible msg stack loc))))


### PR DESCRIPTION
Hey guys,
there are several things on this pull request that I would like to discuss. 
- Currently only the collapsible-exception behavior uses colors for the stacktraces, should the normal behavior also have them?
- I found out that in some cases the exception summaries can be quite long so I added the truncation for all summaries
- the `strip-ansi` function is intentionally duplicated in clojure.cljs and collapsible_exception.cljs since I don't know which one is going to stay on the long run.
- In the lein-light-nrepl I could see that you trim some parts of the stacktrace. I personally trim away the parts below, but I don't know if this should always be done or rather be a user specific stuff.

```
(def lighttable-internals
  #{#"lighttable\.nrepl\.eval"
    #"lighttable\.nrepl\.core"
    #"clojure\.tools\.nrepl\.middleware\.interruptible-eval"})
```
- I'm not a CSS/designer expert so I mostly used the defaults colors from ansi; with two notable exceptions, "red" -> "OrangeRed" and "green" -> "limegreen", since it was quite difficult to read those on the pink stacktrace-background that Lighttable uses for exceptions. Any ideas here?
