### PR TITLE
Fix handler.cljs :require typo

### DIFF
--- a/lein-light-nrepl/src/lighttable/nrepl/handler.clj
+++ b/lein-light-nrepl/src/lighttable/nrepl/handler.clj
@@ -9,7 +9,7 @@
             [lighttable.nrepl.eval :as eval]
             [lighttable.nrepl.cljs :as cljs]
             [lighttable.nrepl.doc :as doc]
-            lighttable.nrepl.auto-complete
+            [lighttable.nrepl.auto-complete :as auto-complete]
             [clojure.repl :as repl]))
 
 (defn with-lt-data [msg]


### PR DESCRIPTION
This PR fixes lighttable.nrepl.handler's :require as reported in issue #91. However, this does not resolve the actual problem. So, this PR is simply a typo fix.
